### PR TITLE
add initial travis testing for GigaScience Galaxy tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python: 2.7
+install:
+  - pip install planemo
+
+script:
+  - planemo --version
+  - planemo shed_lint --report_level warn --tools --fail_level error --recursive .


### PR DESCRIPTION
This will add `planemo lint` test to all repositories that have a `.hsed.yaml` file. This file should be mandatory for all tools and should be added to already existing tools as well.

Read more about `.shed.yml` files at: http://galaxy-iuc-standards.readthedocs.org/en/latest/best_practices/shed_yml.html
